### PR TITLE
Fix feature scripts for npm run

### DIFF
--- a/e2e-tests/all-features-npm.sh
+++ b/e2e-tests/all-features-npm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$PWD
+TMP=$(mktemp -d)
+
+cd $TMP
+
+$DIR/bin/index.js --noQuest --packageManager=npm
+
+cd fp-ts-lib
+
+npm run spell
+npm run build
+npm run lint
+npm run test
+npm run docs
+npm run md

--- a/e2e-tests/all-features-yarn.sh
+++ b/e2e-tests/all-features-yarn.sh
@@ -7,7 +7,7 @@ TMP=$(mktemp -d)
 
 cd $TMP
 
-$DIR/bin/index.js --noQuest
+$DIR/bin/index.js --noQuest --packageManager=yarn
 
 cd fp-ts-lib
 
@@ -15,5 +15,5 @@ yarn run spell
 yarn run build
 yarn run lint
 yarn run test
-yarn run docs-ts
+yarn run docs
 yarn run md

--- a/e2e-tests/all.sh
+++ b/e2e-tests/all.sh
@@ -4,4 +4,5 @@ set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-$DIR/all-features.sh
+$DIR/all-features-yarn.sh
+$DIR/all-features-npm.sh

--- a/src/features/cspell.ts
+++ b/src/features/cspell.ts
@@ -47,7 +47,7 @@ const mkPackageJson = {
     cspell: '^5.5.2',
   },
   scripts: {
-    spell: "yarn cspell '**/*.*'",
+    spell: "cspell '**/*.*'",
   },
 }
 

--- a/src/features/docs-ts.ts
+++ b/src/features/docs-ts.ts
@@ -47,7 +47,7 @@ const mkPackageJson = (config: Config) => ({
     'docs-ts': '^0.6.10',
   },
   scripts: {
-    docs: `${config.packageManager} run docs-ts`,
+    docs: 'docs-ts',
   },
 })
 

--- a/src/features/docs-ts.ts
+++ b/src/features/docs-ts.ts
@@ -42,7 +42,7 @@ type OutFiles = Extends<
 // utils
 // -----------------------------------------------------------------------------
 
-const mkPackageJson = (config: Config) => ({
+const mkPackageJson = () => ({
   devDependencies: {
     'docs-ts': '^0.6.10',
   },
@@ -60,8 +60,7 @@ const packageJson: Effect<FileObjects['PackageJson']> = RTE.scope(
     files: {
       'package.json': { data },
     },
-    config,
-  }) => pipe(mkPackageJson(config), PJ.merge(data), tag('PackageJson'), RTE.of)
+  }) => pipe(mkPackageJson(), PJ.merge(data), tag('PackageJson'), RTE.of)
 )
 
 const gitignore: Effect<FileObjects['Text']> = RTE.scope(

--- a/src/features/eslint.ts
+++ b/src/features/eslint.ts
@@ -53,7 +53,7 @@ const eslintConfig: Linter.Config = {
   rules: {},
 }
 
-const mkPackageJson = (config: Config) => ({
+const mkPackageJson = () => ({
   devDependencies: {
     eslint: '^7.27.0',
     '@typescript-eslint/eslint-plugin': '^4.25.0',
@@ -73,8 +73,7 @@ const packageJson: Effect<FileObjects['PackageJson']> = RTE.scope(
     files: {
       'package.json': { data },
     },
-    config,
-  }) => pipe(mkPackageJson(config), PJ.merge(data), tag('PackageJson'), RTE.of)
+  }) => pipe(mkPackageJson(), PJ.merge(data), tag('PackageJson'), RTE.of)
 )
 
 const eslintIgnore: Effect<FileObjects['Text']> = pipe(

--- a/src/features/eslint.ts
+++ b/src/features/eslint.ts
@@ -60,7 +60,7 @@ const mkPackageJson = (config: Config) => ({
     '@typescript-eslint/parser': '^4.25.0',
   },
   scripts: {
-    lint: `${config.packageManager} run eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0`,
+    lint: 'eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0',
   },
 })
 

--- a/src/features/jest.ts
+++ b/src/features/jest.ts
@@ -51,7 +51,7 @@ const assetsDir = path.join(assetsDirRoot, 'jest')
 // utils
 // -----------------------------------------------------------------------------
 
-const mkPackageJson = (config: Config) => ({
+const mkPackageJson = () => ({
   devDependencies: {
     '@types/jest': '^26.0.20',
     jest: '^26.6.3',
@@ -72,8 +72,7 @@ const packageJson: Effect<FileObjects['PackageJson']> = RTE.scope(
     files: {
       'package.json': { data },
     },
-    config,
-  }) => pipe(mkPackageJson(config), PJ.merge(data), tag('PackageJson'), RTE.of)
+  }) => pipe(mkPackageJson(), PJ.merge(data), tag('PackageJson'), RTE.of)
 )
 
 const jestConfigJs: Effect<FileObjects['Text']> = RTE.scope(({ cap }) =>

--- a/src/features/jest.ts
+++ b/src/features/jest.ts
@@ -58,8 +58,8 @@ const mkPackageJson = (config: Config) => ({
     'ts-jest': '^26.5.3',
   },
   scripts: {
-    test: `${config.packageManager} run jest`,
-    'test:watch': `${config.packageManager} run jest --watch`,
+    test: 'jest',
+    'test:watch': 'jest --watch',
   },
 })
 

--- a/src/features/markdown-magic.ts
+++ b/src/features/markdown-magic.ts
@@ -40,7 +40,7 @@ type OutFiles = Extends<
 // utils
 // -----------------------------------------------------------------------------
 
-const mkPackageJson = (config: Config) => ({
+const mkPackageJson = () => ({
   devDependencies: {
     'markdown-magic': '^2.0.0',
   },
@@ -58,8 +58,7 @@ const packageJson: Effect<FileObjects['PackageJson']> = RTE.scope(
     files: {
       'package.json': { data },
     },
-    config,
-  }) => pipe(mkPackageJson(config), PJ.merge(data), tag('PackageJson'), RTE.of)
+  }) => pipe(mkPackageJson(), PJ.merge(data), tag('PackageJson'), RTE.of)
 )
 
 const main: Effect<OutFiles> = pipe(

--- a/src/features/markdown-magic.ts
+++ b/src/features/markdown-magic.ts
@@ -45,7 +45,7 @@ const mkPackageJson = (config: Config) => ({
     'markdown-magic': '^2.0.0',
   },
   scripts: {
-    md: `${config.packageManager} run markdown`,
+    md: 'markdown',
   },
 })
 

--- a/src/features/prettier.ts
+++ b/src/features/prettier.ts
@@ -50,7 +50,7 @@ const mkPackageJson = (config: Config) => ({
     'prettier-plugin-jsdoc': '^0.3.13',
   },
   scripts: {
-    pretty: `${config.packageManager} run prettier --check .`,
+    pretty: 'prettier --check .',
   },
 })
 

--- a/src/features/prettier.ts
+++ b/src/features/prettier.ts
@@ -44,7 +44,7 @@ type OutFiles = Extends<
 // utils
 // -----------------------------------------------------------------------------
 
-const mkPackageJson = (config: Config) => ({
+const mkPackageJson = () => ({
   devDependencies: {
     prettier: '^2.2.1',
     'prettier-plugin-jsdoc': '^0.3.13',
@@ -63,8 +63,7 @@ const packageJson: Effect<FileObjects['PackageJson']> = RTE.scope(
     files: {
       'package.json': { data },
     },
-    config,
-  }) => pipe(mkPackageJson(config), PJ.merge(data), tag('PackageJson'), RTE.of)
+  }) => pipe(mkPackageJson(), PJ.merge(data), tag('PackageJson'), RTE.of)
 )
 
 const prettierRc: Effect<FileObjects['Json']> = pipe(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Choosing `npm` as package manager results in non-working npm scripts.
Affected scripts: spell*, docs, lint, test, test:watch, md, pretty.

\* Assuming user does not have yarn installed.

## Steps to reproduce

- Run `create-fp-ts-lib --noQuest --packageManager=npm`
- The `package.json` contains the following scripts:
```json
  "scripts": {
    "build": "tsc -p tsconfig.build.json",
    "build:watch": "tsc -w -p tsconfig.build.json",
    "prepublish": "npm run build",
    "pretty": "npm run prettier --check .",
    "lint": "npm run eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0",
    "test": "npm run jest",
    "test:watch": "npm run jest --watch",
    "docs": "npm run docs-ts",
    "spell": "yarn cspell '**/*.*'",
    "md": "npm run markdown"
  }
```
- Try to run `npm run pretty` or one of the above in the "Affected scripts" list.
- Error `npm ERR! missing script: prettier`
```bash
❯ npm run pretty

> fp-ts-lib@1.0.0 pretty /fp-ts-lib
> npm run prettier --check .

npm ERR! missing script: prettier
npm ERR! 
npm ERR! Did you mean this?
npm ERR!     pretty
```


## How Has This Been Tested?
- Tested locally using `npm 7.15.1 / node v16.3.0`, `npm 6.14.8 / node v14.15.1` and `yarn 1.22.11`.
- Splitted e2e `all-features.sh` into `all-features-npm.sh` and `all-features-yarn.sh` to test with both package managers.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

<!-- https://raw.githubusercontent.com/TalAter/open-source-templates/master/PULL_REQUEST_TEMPLATE.md -->